### PR TITLE
Merge Featureimage display to get rid of it 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt update && apt -y upgrade && apt install -y \
 RUN python3 -m pip install --upgrade pip 
 RUN pip3 install \
     opencv-python \
-    matplotlib \
+# matplotlib \
     rospkg \
     pynput
 


### PR DESCRIPTION
Considero que sería bueno hacerle merge con main. El único cambio que tiene es que tiene comentada la dependencia del matplotlib en el dockerfile. De esa forma podemos eliminar la rama, pues ya cumplió su propósito que era publicar el mapa a un tópico. Así, mantenemos mas organizado el repositorio sin ramas volando :)